### PR TITLE
Upped the interval since setInterval takes in ms not seconds.

### DIFF
--- a/client/src/modules/UBW/index.js
+++ b/client/src/modules/UBW/index.js
@@ -20,7 +20,7 @@ type State = {
   data: ?Object,
 };
 
-const INTERVAL = 60 * 60 * 24;
+const INTERVAL = 1000 * 60 * 60 * 24;
 
 class UBW extends React.Component<Props, State> {
   constructor(props: Props) {


### PR DESCRIPTION
It looks like you were trying to set the interval to once every day. However setInterval uses milliseconds and not seconds so in reality the UBW data was polled every 86 seconds.
This should reduce the load on UBW by a lot.